### PR TITLE
revision of PA

### DIFF
--- a/lib/common/constant.h
+++ b/lib/common/constant.h
@@ -27,7 +27,7 @@
 #define PORT_LOAD 3
 #define PORT_ENABLE 3
 #define PORT_DISABLE 3
-#define BYTE_LOAD 0x70
+#define BYTE_LOAD 0x80
 #define BYTE_LOCK 0x00
 #define BYTE_ENABLE 0x40
 #define BYTE_DISABLE 0x00


### PR DESCRIPTION
1. the file constant.h was modified.
   BYTE_LOAD altered from 0x70 to 0x80
2. DEV_COUNT_MAX 144 was not changed.
   在生成随机channel号的代码中，此值最好改成145.但在代码其他地方也用到了该常量，故此处没有改
   3.函数checkReceivedBytes
   其中一个case是0x40，但该byte的低三位不一定为0
   4.函数ba2volt和ba2temp
   电压或温度值 = (int)baEcho[2] \* 128 + (int)baEcho[3]
   但是，返回值的第三个字节即baEcho[2]的高四位难道不是0010和0001？高四位的值难道不该去掉，只取低三位计算电压或温度值？
